### PR TITLE
Fix assertion error in infectious test, and pointer type conversion error

### DIFF
--- a/src/shmem_rw_lock.c
+++ b/src/shmem_rw_lock.c
@@ -11,7 +11,7 @@
  * remainder of the bits are used to count readers.
  */
 long *hvr_rwlock_create_n(const int n) {
-    long *lock = shmem_malloc(n * sizeof(*lock));
+    long *lock = (long *)shmem_malloc(n * sizeof(*lock));
     assert(lock);
     memset(lock, 0x00, n * sizeof(*lock));
     shmem_barrier_all();

--- a/test/infectious_test.c
+++ b/test/infectious_test.c
@@ -401,7 +401,7 @@ int main(int argc, char **argv) {
      * "teleported" to the other end of the portal.
      */
     portals = (portal_t *)shmem_malloc(n_global_portals * sizeof(*portals));
-    assert(portals);
+    assert((n_global_portals == 0) || portals);
     if (pe == 0) {
         fprintf(stderr, "Creating %d portals\n", n_global_portals);
         fprintf(stderr, "%d actors per cell, %d actors in total\n",


### PR DESCRIPTION
In the infectious disease test, if there are 0 portals, some OpenSHMEM implementations(eg. osss-ucx) returns null pointer in shmem_malloc. What the function should return in this case is not specified in the specification, so I modified the assertion to cover different cases.

The pointer type conversion fix in shmem_rw_lock.c is required to write C++ programs with Hoover because g++ is stricter on this matter than gcc.