### PR TITLE
Vertex attributes related fixes

### DIFF
--- a/inc/hvr_sparse_vec.h
+++ b/inc/hvr_sparse_vec.h
@@ -9,9 +9,13 @@
 #define HVR_BUCKETS 128
 
 // The maximum number of features set on a vertex at any time.
+#ifndef HVR_BUCKET_SIZE
 #define HVR_BUCKET_SIZE 7
+#endif
 
+#ifndef HVR_MAX_CONSTANT_ATTRS
 #define HVR_MAX_CONSTANT_ATTRS 3
+#endif
 
 /*
  * Sparse vector for representing properties on each vertex, and accompanying

--- a/src/hoover.c
+++ b/src/hoover.c
@@ -186,7 +186,7 @@ void hvr_sparse_vec_init_with_const_attrs(hvr_sparse_vec_t *vec,
     }
 
     // Initialize constant attributes on this vertex
-    assert(n_const_attrs < HVR_MAX_CONSTANT_ATTRS);
+    assert(n_const_attrs <= HVR_MAX_CONSTANT_ATTRS);
     vec->n_const_features = n_const_attrs;
     memcpy(vec->const_features, const_attr_features,
             n_const_attrs * sizeof(*const_attr_features));

--- a/src/hoover.c
+++ b/src/hoover.c
@@ -272,7 +272,7 @@ static void set_helper(hvr_sparse_vec_t *vec, const unsigned curr_bucket,
             return;
         }
     }
-    assert(bucket_size < HVR_BUCKET_SIZE); // Can hold all features
+    assert(bucket_size < HVR_BUCKET_SIZE); // Can hold one more feature
     vec->features[curr_bucket][bucket_size] = feature;
     vec->values[curr_bucket][bucket_size] = val;
     vec->bucket_size[curr_bucket] = bucket_size + 1;


### PR DESCRIPTION
Make the two macro definitions redefinable using compiler flags.

Fix an assertion error related to the number of constant vertex attributes.

Clarify one comment in set_helper.